### PR TITLE
Ignore Warning message

### DIFF
--- a/Simple_DB.php
+++ b/Simple_DB.php
@@ -117,7 +117,7 @@ class Simple_DB {
 	}
 	
 	public function returnSingleId($a) {
-		return ($a ? array_shift(@array_keys($a)) : false);
+		return ($a ? @array_shift(@array_keys($a)) : false);
 	}
 	
 	private function shiftArray($arr) {


### PR DESCRIPTION
PHP strict mode will prompt warning message.
Only variables should be passed by reference..

https://stackoverflow.com/questions/30392047/array-shift-only-variables-should-be-passed-by-reference-error-in-php